### PR TITLE
Integrate additional trading strategies

### DIFF
--- a/Projekt/my_trading_bot/backtest_runner.py
+++ b/Projekt/my_trading_bot/backtest_runner.py
@@ -7,6 +7,11 @@ from strategies.macd_strategy import MACDStrategy
 from strategies.rsi_strategy import RSIStrategy
 from strategies.sma_strategy import SMAStrategy
 from strategies.dummy_strategy import DummyStrategy
+from strategies.ai_strategy import AIStrategy
+from strategies.dtw_strategy import DTWStrategy
+from strategies.horizontal_pattern_strategy import HorizontalPatternStrategy
+from strategies.bollinger_strategy import BollingerStrategy
+from strategies.zigzag_strategy import ZigZagStrategy
 from config.settings import PREDEFINED_SYMBOLS, CAPITAL, COMMISSION
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -18,7 +23,12 @@ def run_backtests():
         "MACD": MACDStrategy,
         "RSI": RSIStrategy,
         "SMA": SMAStrategy,
-        "DUMMY": DummyStrategy
+        "DUMMY": DummyStrategy,
+        "AI": AIStrategy,
+        "DTW": DTWStrategy,
+        "HORIZONTAL": HorizontalPatternStrategy,
+        "BOLLINGER": BollingerStrategy,
+        "ZIGZAG": ZigZagStrategy
     }
 
     os.makedirs(RESULT_DIR, exist_ok=True)

--- a/Projekt/my_trading_bot/strategies/__init__.py
+++ b/Projekt/my_trading_bot/strategies/__init__.py
@@ -1,0 +1,21 @@
+from .dummy_strategy import DummyStrategy
+from .rsi_strategy import RSIStrategy
+from .macd_strategy import MACDStrategy
+from .sma_strategy import SMAStrategy
+from .ai_strategy import AIStrategy
+from .dtw_strategy import DTWStrategy
+from .horizontal_pattern_strategy import HorizontalPatternStrategy
+from .bollinger_strategy import BollingerStrategy
+from .zigzag_strategy import ZigZagStrategy
+
+__all__ = [
+    'DummyStrategy',
+    'RSIStrategy',
+    'MACDStrategy',
+    'SMAStrategy',
+    'AIStrategy',
+    'DTWStrategy',
+    'HorizontalPatternStrategy',
+    'BollingerStrategy',
+    'ZigZagStrategy'
+]

--- a/Projekt/my_trading_bot/strategies/ai_strategy.py
+++ b/Projekt/my_trading_bot/strategies/ai_strategy.py
@@ -1,0 +1,36 @@
+import backtrader as bt
+from sklearn.linear_model import LogisticRegression
+
+class AIStrategy(bt.Strategy):
+    params = dict(train_period=200)
+
+    def __init__(self):
+        self.dataclose = self.datas[0].close
+        self.rsi = bt.indicators.RSI_SMA(self.dataclose, period=14)
+        self.sma = bt.indicators.SimpleMovingAverage(self.dataclose, period=14)
+        self.model = LogisticRegression()
+        self.trained = False
+
+    def prenext(self):
+        if len(self) >= self.p.train_period and not self.trained:
+            X = []
+            y = []
+            for i in range(-self.p.train_period, -1):
+                rsi_val = float(self.rsi[i])
+                sma_val = float(self.sma[i])
+                if not (bt.math.isnan(rsi_val) or bt.math.isnan(sma_val)):
+                    X.append([rsi_val, sma_val])
+                    y.append(1 if self.dataclose[i+1] > self.dataclose[i] else 0)
+            if X:
+                self.model.fit(X, y)
+                self.trained = True
+
+    def next(self):
+        if not self.trained:
+            self.prenext()
+            return
+        pred = self.model.predict([[self.rsi[0], self.sma[0]]])[0]
+        if not self.position and pred == 1:
+            self.buy()
+        elif self.position and pred == 0:
+            self.close()

--- a/Projekt/my_trading_bot/strategies/bollinger_strategy.py
+++ b/Projekt/my_trading_bot/strategies/bollinger_strategy.py
@@ -1,0 +1,15 @@
+import backtrader as bt
+
+class BollingerStrategy(bt.Strategy):
+    params = dict(period=20, devfactor=2)
+
+    def __init__(self):
+        self.bbands = bt.indicators.BollingerBands(self.datas[0].close,
+                                                   period=self.p.period,
+                                                   devfactor=self.p.devfactor)
+
+    def next(self):
+        if not self.position and self.datas[0].close[0] < self.bbands.lines.bot[0]:
+            self.buy()
+        elif self.position and self.datas[0].close[0] > self.bbands.lines.mid[0]:
+            self.close()

--- a/Projekt/my_trading_bot/strategies/dtw_strategy.py
+++ b/Projekt/my_trading_bot/strategies/dtw_strategy.py
@@ -1,0 +1,18 @@
+import backtrader as bt
+
+class DTWStrategy(bt.Strategy):
+    params = dict(window=10, threshold=15)
+
+    def __init__(self):
+        self.dataclose = self.datas[0].close
+        self.pattern = list(range(self.p.window))
+
+    def next(self):
+        if len(self.dataclose) < self.p.window:
+            return
+        recent = [float(self.dataclose[-i]) for i in range(self.p.window, 0, -1)]
+        distance = sum((recent[i] - self.pattern[i]) ** 2 for i in range(self.p.window)) ** 0.5
+        if not self.position and distance < self.p.threshold:
+            self.buy()
+        elif self.position and distance > self.p.threshold * 1.5:
+            self.close()

--- a/Projekt/my_trading_bot/strategies/horizontal_pattern_strategy.py
+++ b/Projekt/my_trading_bot/strategies/horizontal_pattern_strategy.py
@@ -1,0 +1,16 @@
+import backtrader as bt
+
+class HorizontalPatternStrategy(bt.Strategy):
+    params = dict(lookback=20)
+
+    def next(self):
+        if len(self) < self.p.lookback:
+            return
+        highs = [self.data.high[-i] for i in range(1, self.p.lookback + 1)]
+        lows = [self.data.low[-i] for i in range(1, self.p.lookback + 1)]
+        max_high = max(highs)
+        min_low = min(lows)
+        if not self.position and self.data.close[0] > max_high:
+            self.buy()
+        elif self.position and self.data.close[0] < min_low:
+            self.close()

--- a/Projekt/my_trading_bot/strategies/zigzag_strategy.py
+++ b/Projekt/my_trading_bot/strategies/zigzag_strategy.py
@@ -1,0 +1,20 @@
+import backtrader as bt
+
+class ZigZagStrategy(bt.Strategy):
+    params = dict(perc=5)
+
+    def __init__(self):
+        self.last_pivot = None
+
+    def next(self):
+        price = self.data.close[0]
+        if self.last_pivot is None:
+            self.last_pivot = price
+            return
+        change = (price - self.last_pivot) / self.last_pivot * 100
+        if not self.position and change >= self.p.perc:
+            self.buy()
+            self.last_pivot = price
+        elif self.position and change <= -self.p.perc:
+            self.close()
+            self.last_pivot = price

--- a/Projekt/requirements.txt
+++ b/Projekt/requirements.txt
@@ -3,3 +3,6 @@ plotly
 pandas
 backtrader
 quantstats
+scikit-learn
+fastdtw
+scipy


### PR DESCRIPTION
## Summary
- add AI, DTW, horizontal pattern, Bollinger bands and ZigZag strategies
- expose all strategies in package init
- wire new strategies into backtest runner
- extend requirements with needed packages
- refine AI and DTW implementations

## Testing
- `pip install scikit-learn fastdtw scipy pandas yfinance`
- `python Projekt/my_trading_bot/backtest_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_687510a5df8c8331b585fb7af0d68a55